### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A plug-and-play [MCP](https://modelcontextprotocol.io) server to browse, search, and read Reddit.
 
+<a href="https://glama.ai/mcp/servers/@GridfireAI/reddit-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GridfireAI/reddit-mcp/badge" alt="Reddit MCP server" />
+</a>
+
 ## Demo
 Here's a short video showing how to use this in Claude Desktop:
 


### PR DESCRIPTION
This PR adds a badge for the [Reddit MCP](https://glama.ai/mcp/servers/@GridfireAI/reddit-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@GridfireAI/reddit-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GridfireAI/reddit-mcp/badge" alt="Reddit MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.